### PR TITLE
Add subject dropdown to Contact Us page (#16)

### DIFF
--- a/src/Component/Contact.jsx
+++ b/src/Component/Contact.jsx
@@ -4,12 +4,42 @@ const Contact = () => (
   <section className="max-w-xl mx-auto py-16 px-4 animate-fade-in">
     <h2 className="text-3xl font-bold mb-4 text-center">Contact Us</h2>
     <form className="bg-white shadow rounded-lg p-8 flex flex-col gap-4">
-      <input type="text" placeholder="Your Name" className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition" />
-      <input type="email" placeholder="Your Email" className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition" />
-      <textarea placeholder="Your Message" className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition" rows={4} />
-      <button type="submit" className="bg-black text-white py-2 rounded hover:bg-gray-800 transition">Send Message</button>
+      <input
+        type="text"
+        placeholder="Your Name"
+        className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+      />
+      <input
+        type="email"
+        placeholder="Your Email"
+        className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+      />
+      <select
+        className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+        defaultValue=""
+        required
+      >
+        <option value="" disabled>
+          Select a subject
+        </option>
+        <option value="general">General Inquiry</option>
+        <option value="bug">Bug Report</option>
+        <option value="feature">Feature Request</option>
+        <option value="other">Other</option>
+      </select>
+      <textarea
+        placeholder="Your Message"
+        className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+        rows={4}
+      />
+      <button
+        type="submit"
+        className="bg-black text-white py-2 rounded hover:bg-gray-800 transition"
+      >
+        Send Message
+      </button>
     </form>
   </section>
 );
 
-export default Contact; 
+export default Contact;


### PR DESCRIPTION
Added a subject selection dropdown to the Contact Us form as per issue #16. This helps users categorize their messages—enhancing clarity and UX.
Close #16