### PR TITLE
improve homepage ui and change bg and font colors in dark mode 

### DIFF
--- a/src/Component/About.jsx
+++ b/src/Component/About.jsx
@@ -3,15 +3,15 @@ const About = () => (
     <h2 className="text-4xl md:text-5xl font-extrabold mb-6 text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600">
       About BuildOnCoffee
     </h2>
-    <p className="text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto mb-6">
+    <p className="text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto mb-6 dark:text-gray-300">
       <span className="font-bold text-blue-700">BuildOnCoffee</span> is a{" "}
-      <span className="font-semibold text-gray-900">
+      <span className="font-semibold text-gray-900 dark:text-gray-300">
         modern, community-driven platform
       </span>{" "}
       dedicated to helping developers discover, share, and use the best tools
       and resources for building software.
     </p>
-    <p className="text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto mb-10">
+    <p className="text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto mb-10 dark:text-gray-300">
       Our mission is to{" "}
       <span className="text-purple-700 font-medium">
         empower developers of all backgrounds
@@ -23,7 +23,7 @@ const About = () => (
       , and a vibrant space for collaboration.
     </p>
 
-    <div className="grid grid-cols-1 md:grid-cols-2 items-center gap-12 mb-20">
+    <div className="grid grid-cols-1 md:grid-cols-2 items-center gap-12 mb-20 dark:text-gray-300">
       <img
         src="./perpex.png"
         alt="BuildOnCoffee Logo"
@@ -31,11 +31,11 @@ const About = () => (
       />
 
       <div className="text-left">
-        <h2 className="text-2xl md:text-3xl font-extrabold mb-2 text-transparent bg-clip-text bg-black">
+        <h2 className="text-2xl md:text-3xl font-extrabold mb-2 text-transparent bg-clip-text bg-black dark:text-white">
           Why BuildOnCoffee?
         </h2>
 
-        <ul className=" text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto list-disc list-inside">
+        <ul className=" text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto list-disc list-inside dark:text-gray-300">
           <li>
             <span className="font-semibold text-blue-700">Discover</span>{" "}
             top-rated tools and resources for developers, all in one place.

--- a/src/Component/Contact.jsx
+++ b/src/Component/Contact.jsx
@@ -33,7 +33,7 @@ const Contact = () => {
   return (
     <section className="max-w-xl mx-auto py-16 px-4 animate-fade-in">
       <h2 className="text-3xl font-bold mb-4 text-center">Contact Us</h2>
-      <p className="text-gray-600 mb-8 text-center">
+      <p className="text-gray-600 mb-8 text-center dark:text-gray-300">
         Have a question, suggestion, or want to contribute? Fill out the form below and we’ll get back to you!
       </p>
       <form
@@ -45,27 +45,27 @@ const Contact = () => {
           type="text"
           name="name"
           placeholder="Your Name"
-          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition dark:text-black"
           required
         />
         <input
           type="email"
           name="user_email"
           placeholder="Your Email"
-          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition dark:text-black"
           required
         />
         <input
           type="text"
           name="title"
           placeholder="Subject / Title"
-          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition dark:text-black"
           required
         />
         <textarea
           name="message"
           placeholder="Your Message"
-          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition"
+          className="border p-3 rounded focus:outline-none focus:ring-2 focus:ring-black transition dark:text-black"
           rows={4}
           required
         />

--- a/src/Component/Tools/LearnTools.jsx
+++ b/src/Component/Tools/LearnTools.jsx
@@ -9,13 +9,13 @@ const LearnTools = () => {
   return (
     <div className="flex flex-col md:flex-row bg-white rounded shadow p-6">
       <div className="md:w-1/4 border-r md:pr-4 mb-4 md:mb-0">
-        <h2 className="text-lg font-semibold mb-2">Select Tool</h2>
+        <h2 className="text-lg font-semibold mb-2 dark:text-black">Select Tool</h2>
         {learnToolsList.map((tool) => (
           <button
             key={tool}
             onClick={() => setSelectedTool(tool)}
             className={`block w-full text-left px-4 py-2 mb-2 rounded transition font-medium ${
-              selectedTool === tool ? 'bg-blue-600 text-white' : 'bg-gray-100 hover:bg-gray-200'
+              selectedTool === tool ? 'bg-blue-600 text-white' : 'bg-gray-100 hover:bg-gray-200' 
             }`}
           >
             {tool}

--- a/src/Component/WhatWeDoDifferently.jsx
+++ b/src/Component/WhatWeDoDifferently.jsx
@@ -56,7 +56,7 @@ const WhatWeDoDifferently = () => {
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5 dark:opacity-10">
         <div className="absolute inset-0" style={{
-          backgroundImage: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.4'%3E%3Ccircle cx='30' cy='30' r='2'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E"),
+          backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'60\' height=\'60\' viewBox=\'0 0 60 60\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cg fill=\'none\' fill-rule=\'evenodd\'%3E%3Cg fill=\'%239C92AC\' fill-opacity=\'0.4\'%3E%3Ccircle cx=\'30\' cy=\'30\' r=\'2\'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")',
         }} />
       </div>
 
@@ -104,7 +104,7 @@ const WhatWeDoDifferently = () => {
                 <div className="h-full bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-2xl p-8 border border-gray-200/20 dark:border-gray-700/20 shadow-lg hover:shadow-2xl transition-all duration-500 group-hover:border-blue-300/30 dark:group-hover:border-blue-600/30">
                   {/* Animated background gradient */}
                   <motion.div
-                    className={absolute inset-0 bg-gradient-to-br ${feature.color} opacity-0 group-hover:opacity-5 rounded-2xl transition-opacity duration-500}
+                    className='absolute inset-0 bg-gradient-to-br ${feature.color} opacity-0 group-hover:opacity-5 rounded-2xl transition-opacity duration-500'
                     initial={false}
                   />
 
@@ -114,13 +114,13 @@ const WhatWeDoDifferently = () => {
                     whileHover={{ scale: 1.1, rotate: 5 }}
                     transition={{ duration: 0.2 }}
                   >
-                    <div className={w-16 h-16 bg-gradient-to-br ${feature.color} rounded-xl flex items-center justify-center shadow-lg group-hover:shadow-xl transition-shadow duration-300}>
+                    <div className='w-16 h-16 bg-gradient-to-br ${feature.color} rounded-xl flex items-center justify-center shadow-lg group-hover:shadow-xl transition-shadow duration-300'>
                       <Icon className="w-8 h-8 text-white" />
                     </div>
                     
                     {/* Floating animation dot */}
                     <motion.div
-                      className={absolute -top-2 -right-2 w-4 h-4 bg-gradient-to-r ${feature.color} rounded-full opacity-0 group-hover:opacity-100}
+                      className='absolute -top-2 -right-2 w-4 h-4 bg-gradient-to-r ${feature.color} rounded-full opacity-0 group-hover:opacity-100'
                       animate={inView ? {
                         scale: [0, 1.2, 1],
                         opacity: [0, 1, 0.8],
@@ -145,7 +145,7 @@ const WhatWeDoDifferently = () => {
 
                   {/* Hover effect line */}
                   <motion.div
-                    className={absolute bottom-0 left-0 h-1 bg-gradient-to-r ${feature.color} rounded-b-2xl}
+                    className='absolute bottom-0 left-0 h-1 bg-gradient-to-r ${feature.color} rounded-b-2xl'
                     initial={{ width: 0 }}
                     whileHover={{ width: '100%' }}
                     transition={{ duration: 0.3 }}


### PR DESCRIPTION
changed font colors for differnt pages and also improved homepage
about page before:
<img width="1886" height="973" alt="image" src="https://github.com/user-attachments/assets/3988143b-6b01-49d5-84b7-297194d79481" />
about page after changing:
<img width="1882" height="950" alt="image" src="https://github.com/user-attachments/assets/fcf8496b-956a-4f80-9127-ab8674511617" />

home page before:
<img width="1890" height="983" alt="image" src="https://github.com/user-attachments/assets/c37786bc-6b6f-4984-885a-738581674705" />
home page after changing:
<img width="1884" height="1038" alt="image" src="https://github.com/user-attachments/assets/0afe4f70-f2a2-4f1f-ace9-6dd95ac1014a" />

contact page before :
<img width="1891" height="988" alt="image" src="https://github.com/user-attachments/assets/7b45a9bc-dd78-43f3-a3aa-8e3af208ca5d" />
 contact page after changing:
<img width="1879" height="1040" alt="image" src="https://github.com/user-attachments/assets/3fb26934-eb83-4516-8dd5-7df2cbdf8361" />


fixed bugs in other pages and improved readablity in dark mode for users