### PR TITLE
fix: improve course text visibility in dark mode in All Courses section

### DIFF
--- a/src/Component/CoursesList.jsx
+++ b/src/Component/CoursesList.jsx
@@ -33,7 +33,7 @@ const CoursesList = () => {
       )}
 
       <section className="max-w-6xl mx-auto pt-8 pb-16 px-4 animate-fade-in relative">
-        <h2 className="text-3xl font-bold mb-8 text-center relative">
+        <h2 className="text-3xl font-bold mb-8 text-center relative dark:text-white">
           All Courses
         </h2>
 

--- a/src/Component/ToolCard.jsx
+++ b/src/Component/ToolCard.jsx
@@ -14,8 +14,8 @@ const ToolCard = ({
   dateAdded // ✅ accept dateAdded as prop
 }) => (
   <div
-    className={`relative border rounded-xl p-4 shadow-lg transition-all bg-white flex flex-col items-start group cursor-pointer ${
-      selected ? 'ring-2 ring-black' : 'hover:shadow-2xl hover:bg-gray-100'
+    className={`relative border rounded-xl p-4 shadow-lg transition-all bg-white dark:bg-gray-800 flex flex-col items-start group cursor-pointer ${
+      selected ? 'ring-2 ring-black dark:ring-gray-300' : 'hover:shadow-2xl hover:bg-gray-100 dark:hover:bg-gray-700'
     }`}
     onClick={onClick}
   >
@@ -37,13 +37,13 @@ const ToolCard = ({
           />
         </div>
       )}
-      <h3 className="text-xl font-bold mb-1 group-hover:text-black transition-colors text-left">
+      <h3 className="text-xl font-bold mb-1 group-hover:text-black dark:text-white dark:group-hover:text-white transition-colors text-left">
         {name}
       </h3>
     </div>
 
     {/* Description */}
-    <p className="text-gray-600 mt-1 group-hover:text-gray-800 transition-colors text-left mb-2">
+    <p className="text-gray-600 dark:text-gray-300 mt-1 group-hover:text-gray-800 dark:group-hover:text-gray-100 transition-colors text-left mb-2">
       {description}
     </p>
 
@@ -69,7 +69,7 @@ const ToolCard = ({
           href={docs}
           target="_blank"
           rel="noopener noreferrer"
-          className="underline hover:text-black"
+          className="underline hover:text-black dark:text-gray-400 dark:hover:text-white"
           onClick={(e) => e.stopPropagation()}
         >
           Documentation
@@ -80,7 +80,7 @@ const ToolCard = ({
     {/* References */}
     {references.length > 0 && (
       <div className="w-full">
-        <h4 className="font-semibold text-sm mb-1">References:</h4>
+        <h4 className="font-semibold text-sm mb-1 dark:text-white">References:</h4>
         <div className="flex flex-wrap gap-3 items-start">
           {references.map((ref, i) =>
             ref.image ? (
@@ -101,7 +101,7 @@ const ToolCard = ({
                   />
                 </div>
                 {ref.label && (
-                  <div className="text-xs text-center mt-1">{ref.label}</div>
+                  <div className="text-xs text-center mt-1 dark:text-gray-300">{ref.label}</div>
                 )}
               </a>
             ) : (
@@ -110,7 +110,7 @@ const ToolCard = ({
                   href={ref.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-black"
+                  className="underline hover:text-black dark:text-gray-400 dark:hover:text-white"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {ref.label}
@@ -128,7 +128,7 @@ const ToolCard = ({
         href={link}
         target="_blank"
         rel="noopener noreferrer"
-        className="mt-2 inline-block text-white bg-black px-4 py-2 rounded hover:bg-gray-800 transition w-full text-center"
+        className="mt-2 inline-block text-white bg-black dark:bg-white dark:text-black px-4 py-2 rounded hover:bg-gray-800 dark:hover:bg-gray-200 transition w-full text-center"
         onClick={(e) => e.stopPropagation()}
       >
         🚀 Go to Course


### PR DESCRIPTION
## 🔧 Fix: Improve Course Text Visibility in Dark Mode

### 🐛 Issue Description
In dark mode, the course names and related text in the **"All Courses"** section of the [BuildOnCoffee website](https://build-on-coffee.vercel.app/) were not visible due to poor contrast with the background. This negatively impacted readability and user experience.

### 🎯 What This PR Does
- Increases text contrast for course titles and related content in dark mode.
- Ensures consistent readability across both light and dark themes.
- Fix applied using appropriate Tailwind CSS classes (or relevant CSS if custom styles were used).

### ✅ Steps to Reproduce the Bug (Before Fix)
1. Visit [BuildOnCoffee](https://build-on-coffee.vercel.app/)
2. Switch to **dark mode** from the theme settings.
3. Scroll to the **"Courses"** section.
4. Observe that the course names and other text are barely visible or completely hidden.

### 📸 Screenshots (Before & After)
<!-- Optional: You can add screenshots here -->
<details>
<summary>Click to expand</summary>

**Before (Dark Mode):**
- Course text blends into the background

<img width="1435" height="857" alt="Screenshot 2025-08-04 at 12 32 54 PM" src="https://github.com/user-attachments/assets/e93c6b38-e3ff-481c-8be8-20f159f49179" />


**After (Dark Mode):**
- Course text is clearly visible and legible
<img width="1438" height="807" alt="Screenshot 2025-08-04 at 1 05 33 PM" src="https://github.com/user-attachments/assets/3ac6125e-b348-4dbb-bcdb-853a450ce010" />

</details>


### 🙋‍♂️ Contributor
Hi @anup2702, I am a **GSSoC '25 contributor**. Kindly review and merge this PR. I’ve ensured the fix is clean and scoped only to this issue. Let me know if any changes are required.

---

It close Issue no  #134  
