### PR TITLE
fixes issue #132

### DIFF
--- a/src/Component/About.jsx
+++ b/src/Component/About.jsx
@@ -35,7 +35,7 @@ const About = () => (
           Why BuildOnCoffee?
         </h2>
 
-        <ul className=" text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto list-disc list-inside dark:text-gray-300">
+        <ul className=" text-lg md:text-xl leading-relaxed text-gray-800 max-w-3xl mx-auto list-none dark:text-gray-300">
           <li>
             <span className="font-semibold text-blue-700">Discover</span>{" "}
             top-rated tools and resources for developers, all in one place.


### PR DESCRIPTION
removing bulleting in about page 
<img width="1870" height="1017" alt="image" src="https://github.com/user-attachments/assets/6db03fe0-9eab-4dfc-bac8-8ede4f7a3068" />

please close the issue #132 after merging