### PR TITLE
Updated 'All tools section' in dark mode

### DIFF
--- a/src/Component/ToolsList.jsx
+++ b/src/Component/ToolsList.jsx
@@ -10,7 +10,7 @@ const ToolsList = () => {
   return (
     <section className="max-w-6xl mx-auto py-16 px-4 animate-fade-in">
       <h2 className="text-3xl font-bold mb-8 text-center">All Tools</h2>
-      <div className="flex flex-col md:flex-row bg-white rounded shadow p-6">
+      <div className="flex flex-col md:flex-row dark:bg-gray-900 rounded shadow p-6">
         {/* Sidebar Tool Buttons */}
         <div className="md:w-1/4 border-r md:pr-4 mb-4 md:mb-0">
           <h2 className="text-lg font-semibold mb-2">Select Tool</h2>
@@ -20,8 +20,8 @@ const ToolsList = () => {
               onClick={() => setSelectedTool(tool)}
               className={`block w-full text-left px-4 py-2 mb-2 rounded transition font-medium ${
                 selectedTool === tool
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-100 hover:bg-gray-200"
+                  ? "bg-blue-600 text-white font-bold"
+                  : "bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-black dark:text-white font-medium"
               }`}
             >
               {tool}


### PR DESCRIPTION
Hey @anup2702  , I have done the changes.

**What does this PR do?**
This PR updates the appearance of the "All tools" section to properly support and display in dark mode, ensuring visual consistency and improved user experience when dark mode is enabled.

**_Related Issues_**
Closes #129 

**_Type of Change_**
UI Enhancement

**_Testing_**
1. Tested in Chrome.
2. Tested in Brave.
3. Tested in Microsoft Edge.
4. Verified existing functionality still works.

**_Screenshots_**

**_Before_**
<img width="1920" height="1080" alt="Screenshot (353)" src="https://github.com/user-attachments/assets/cc0ff66b-9083-4c75-8788-06e5aa30fe1f" />

**_After_**
<img width="1920" height="1080" alt="Screenshot (355)" src="https://github.com/user-attachments/assets/a67ada97-b025-45c2-b5c3-845e37b4b033" />

Kindly review the changes at your convenience. If all looks good, a merge would be much appreciated. Thank you @anup2702 
 for letting me contribute to this project!