### PR TITLE
feat(roadmaps): persist completed steps in localStorage

### DIFF
--- a/src/Component/Roadmaps/DevOpsRoadmap.jsx
+++ b/src/Component/Roadmaps/DevOpsRoadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { devOpsSteps } from "../../../data/devOpsRoadmap";
 import { ListChecks, FileText, Video } from "lucide-react";
@@ -13,16 +13,24 @@ const extractYouTubeID = (url) => {
 const DevOpsRoadmap = () => {
   const [openStep, setOpenStep] = useState(null);
   const [completed, setCompleted] = useState([]);
-  
+
+  useEffect(() => {
+    const storedCompleted = localStorage.getItem("completedDevOpsSteps");
+    if (storedCompleted) {
+      setCompleted(JSON.parse(storedCompleted));
+    }
+  }, []);
 
   const toggleStep = (index) => {
     setOpenStep(openStep === index ? null : index);
   };
 
   const toggleComplete = (index) => {
-    setCompleted((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
-    );
+    const newCompleted = completed.includes(index)
+      ? completed.filter((i) => i !== index)
+      : [...completed, index];
+    setCompleted(newCompleted);
+    localStorage.setItem("completedDevOpsSteps", JSON.stringify(newCompleted));
   };
 
   return (

--- a/src/Component/Roadmaps/DsaRoadmap.jsx
+++ b/src/Component/Roadmaps/DsaRoadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { dsaSteps } from "../../../data/dsaRoadmap";
 import { ListChecks, FileText, Video } from "lucide-react";
@@ -14,14 +14,23 @@ const DsaRoadmap = () => {
   const [openStep, setOpenStep] = useState(null);
   const [completed, setCompleted] = useState([]);
 
+  useEffect(() => {
+    const storedCompleted = localStorage.getItem("completedDsaSteps");
+    if (storedCompleted) {
+      setCompleted(JSON.parse(storedCompleted));
+    }
+  }, []);
+
   const toggleStep = (index) => {
     setOpenStep(openStep === index ? null : index);
   };
 
   const toggleComplete = (index) => {
-    setCompleted((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
-    );
+    const newCompleted = completed.includes(index)
+      ? completed.filter((i) => i !== index)
+      : [...completed, index];
+    setCompleted(newCompleted);
+    localStorage.setItem("completedDsaSteps", JSON.stringify(newCompleted));
   };
 
   return (

--- a/src/Component/Roadmaps/MobileDevRoadmap.jsx
+++ b/src/Component/Roadmaps/MobileDevRoadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { mobileDevSteps } from "../../../data/mobileDevRoadmap";
 import { ListChecks, FileText, Video } from "lucide-react";
@@ -14,13 +14,25 @@ const MobileDevRoadmap = () => {
   const [openStep, setOpenStep] = useState(null);
   const [completed, setCompleted] = useState([]);
 
+  useEffect(() => {
+    const storedCompleted = localStorage.getItem("completedMobileDevSteps");
+    if (storedCompleted) {
+      setCompleted(JSON.parse(storedCompleted));
+    }
+  }, []);
+
   const toggleStep = (index) => {
     setOpenStep(openStep === index ? null : index);
   };
 
   const toggleComplete = (index) => {
-    setCompleted((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+    const newCompleted = completed.includes(index)
+      ? completed.filter((i) => i !== index)
+      : [...completed, index];
+    setCompleted(newCompleted);
+    localStorage.setItem(
+      "completedMobileDevSteps",
+      JSON.stringify(newCompleted)
     );
   };
 

--- a/src/Component/Roadmaps/OpenSourceRoadmap.jsx
+++ b/src/Component/Roadmaps/OpenSourceRoadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { openSourceSteps } from "../../../data/openSourceJourney";
 import { ListChecks, FileText, Video } from "lucide-react";
@@ -14,13 +14,25 @@ const OpenSourceRoadmap = () => {
   const [openStep, setOpenStep] = useState(null);
   const [completed, setCompleted] = useState([]);
 
+  useEffect(() => {
+    const storedCompleted = localStorage.getItem("completedOpenSourceSteps");
+    if (storedCompleted) {
+      setCompleted(JSON.parse(storedCompleted));
+    }
+  }, []);
+
   const toggleStep = (index) => {
     setOpenStep(openStep === index ? null : index);
   };
 
   const toggleComplete = (index) => {
-    setCompleted((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+    const newCompleted = completed.includes(index)
+      ? completed.filter((i) => i !== index)
+      : [...completed, index];
+    setCompleted(newCompleted);
+    localStorage.setItem(
+      "completedOpenSourceSteps",
+      JSON.stringify(newCompleted)
     );
   };
 

--- a/src/Component/Roadmaps/SystemDesignRoadmap.jsx
+++ b/src/Component/Roadmaps/SystemDesignRoadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { systemDesignRoadmap } from "../../../data/systemDesignRoadmap";
 import { ListChecks, FileText, Video } from "lucide-react";
@@ -13,15 +13,26 @@ const extractYouTubeID = (url) => {
 const SystemDesignRoadmap = () => {
   const [openStep, setOpenStep] = useState(null);
   const [completed, setCompleted] = useState([]);
-  
+
+  useEffect(() => {
+    const storedCompleted = localStorage.getItem("completedSystemDesignSteps");
+    if (storedCompleted) {
+      setCompleted(JSON.parse(storedCompleted));
+    }
+  }, []);
 
   const toggleStep = (index) => {
     setOpenStep(openStep === index ? null : index);
   };
 
   const toggleComplete = (index) => {
-    setCompleted((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+    const newCompleted = completed.includes(index)
+      ? completed.filter((i) => i !== index)
+      : [...completed, index];
+    setCompleted(newCompleted);
+    localStorage.setItem(
+      "completedSystemDesignSteps",
+      JSON.stringify(newCompleted)
     );
   };
 

--- a/src/Component/Roadmaps/WebDevRoadmap.jsx
+++ b/src/Component/Roadmaps/WebDevRoadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { webDevSteps } from "../../../data/webDevRoadmap";
 import { ListChecks, FileText, Video } from "lucide-react";
@@ -14,14 +14,23 @@ const WebDevRoadmap = () => {
   const [openStep, setOpenStep] = useState(null);
   const [completed, setCompleted] = useState([]);
 
+  useEffect(() => {
+    const storedCompleted = localStorage.getItem("completedWebDevSteps");
+    if (storedCompleted) {
+      setCompleted(JSON.parse(storedCompleted));
+    }
+  }, []);
+
   const toggleStep = (index) => {
     setOpenStep(openStep === index ? null : index);
   };
 
   const toggleComplete = (index) => {
-    setCompleted((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
-    );
+    const newCompleted = completed.includes(index)
+      ? completed.filter((i) => i !== index)
+      : [...completed, index];
+    setCompleted(newCompleted);
+    localStorage.setItem("completedWebDevSteps", JSON.stringify(newCompleted));
   };
 
   return (


### PR DESCRIPTION
Add useEffect hooks to load persisted completed steps from localStorage on component mount Update toggleComplete handlers to persist changes to localStorage

<img width="1440" height="625" alt="Screenshot 2025-08-09 at 1 25 16 AM" src="https://github.com/user-attachments/assets/4d0f13cd-973a-4161-977a-66c83f29f022" />


It fixes #216 


Happy to discuss about it further 