### PR TITLE
feat: add devops & cloud learning path to roadmap

### DIFF
--- a/data/learningPaths.js
+++ b/data/learningPaths.js
@@ -36,5 +36,95 @@ export const learningPaths = [
       { id: "w4-microservices", label: "Week 4: Introduction to Microservices", link: "/roadmap/system-design" },
       { id: "proj-2", label: "Project: Build a Simple E-commerce API", link: "/roadmap/web-development" },
     ],
-  }
+  },
+  {
+  slug: "devops-cloud-learning-path",
+  title: "DevOps & Cloud Learning Path",
+  duration: "45 Days",
+  level: "Intermediate",
+  description:
+    "A comprehensive and hands-on learning path covering DevOps principles, CI/CD pipelines, containerization, orchestration, Infrastructure as Code, and Cloud Computing (AWS/GCP/Azure). Designed for developers and system admins to transition into modern DevOps & Cloud roles.",
+  milestones: [
+    {
+      id: "w1-devops-linux",
+      label: "Week 1: DevOps Fundamentals & Linux Essentials",
+      details: [
+        "Understand DevOps culture, principles, and lifecycle.",
+        "Basics of Linux commands, file systems, users & permissions.",
+        "Shell scripting for automation.",
+        "Hands-on: Set up a Linux VM (local or cloud)."
+      ],
+      link: "/roadmap/devops"
+    },
+    {
+      id: "w2-git",
+      label: "Week 2: Git & Version Control Mastery",
+      details: [
+        "Version control concepts (local vs remote).",
+        "Branching, merging, rebasing, and conflict resolution.",
+        "Git workflows (Git Flow, trunk-based development).",
+        "Hands-on: Host code on GitHub/GitLab, manage PRs."
+      ],
+      link: "/roadmap/devops"
+    },
+    {
+      id: "w3-docker",
+      label: "Week 3: Docker & Containerization",
+      details: [
+        "Introduction to containers vs virtual machines.",
+        "Docker architecture & commands.",
+        "Building, tagging, and pushing images.",
+        "Docker Compose for multi-container apps.",
+        "Hands-on: Containerize a sample Node.js/React app."
+      ],
+      link: "/roadmap/devops"
+    },
+    {
+      id: "w4-kubernetes",
+      label: "Week 4: Kubernetes & Container Orchestration",
+      details: [
+        "Kubernetes architecture (Pods, Nodes, Services).",
+        "YAML manifests & deployments.",
+        "ConfigMaps, Secrets, and scaling applications.",
+        "Monitoring and logging basics.",
+        "Hands-on: Deploy Dockerized app to a local K8s cluster (Minikube/Kind)."
+      ],
+      link: "/roadmap/devops"
+    },
+    {
+      id: "w5-cloud",
+      label: "Week 5: Cloud Essentials (AWS/GCP/Azure)",
+      details: [
+        "Cloud concepts: Regions, Availability Zones, pricing.",
+        "Compute (EC2/VMs), Storage (S3/Blob), Networking (VPCs, Firewalls).",
+        "Identity & Access Management (IAM).",
+        "Hands-on: Deploy a simple web app on a cloud provider."
+      ],
+      link: "/roadmap/cloud-computing"
+    },
+    {
+      id: "w6-iac",
+      label: "Week 6: Infrastructure as Code (Terraform) + CI/CD",
+      details: [
+        "Introduction to IaC & Terraform basics.",
+        "Writing Terraform configuration files for cloud infra.",
+        "CI/CD pipelines with GitHub Actions/Jenkins.",
+        "Hands-on: Automate cloud infrastructure and app deployment with Terraform + CI/CD."
+      ],
+      link: "/roadmap/devops"
+    },
+    {
+      id: "proj-3",
+      label: "Final Project: Deploy a Containerized App to the Cloud",
+      details: [
+        "Build a full CI/CD pipeline for a sample app.",
+        "Containerize the app with Docker.",
+        "Deploy using Kubernetes on AWS/GCP/Azure.",
+        "Use Terraform for infra setup.",
+        "Document & present end-to-end deployment workflow."
+      ],
+      link: "/roadmap/devops"
+    }
+  ]
+}
 ];


### PR DESCRIPTION
This PR introduces a new **45-day structured learning path** focused on **DevOps and Cloud Computing**, designed for developers looking to transition into **DevOps & Cloud roles**.  

The path covers key areas such as:  
- DevOps principles and culture  
- CI/CD pipeline implementation  
- Containerization with Docker  
- Orchestration with Kubernetes  
- Cloud computing fundamentals (AWS, GCP, Azure)  
- Infrastructure as Code with Terraform  
- A final capstone project deploying a containerized app to the cloud  

This structured roadmap ensures both **theoretical understanding** and **hands-on practice**, preparing learners for real-world DevOps workflows.  

---

## Key Additions  
- **New Learning Path**: `devops-cloud-learning-path`  
- **Duration**: 45 Days  
- **Level**: Intermediate  

### Weekly Breakdown  
- **Week 1** → DevOps Fundamentals & Linux Essentials  
- **Week 2** → Git & Version Control Mastery  
- **Week 3** → Docker & Containerization  
- **Week 4** → Kubernetes & Orchestration  
- **Week 5** → Cloud Essentials (AWS/GCP/Azure)  
- **Week 6** → Infrastructure as Code (Terraform) + CI/CD  
- **Final Project** → Deploy a containerized app on the cloud using Kubernetes & Terraform  

---

## Screenshot  
<img width="713" height="635" alt="Screenshot 2025-08-25 at 9 34 46 PM" src="https://github.com/user-attachments/assets/cb3c8cbb-290e-4164-be6a-f7fdb62ebd51" />  

## Issue Fixed  
Fixes #317  
