### PR TITLE
Fix: aligned glossary cards and improved UI consistency

### DIFF
--- a/src/Component/Glossary/Glossary.jsx
+++ b/src/Component/Glossary/Glossary.jsx
@@ -58,10 +58,10 @@ const Glossary = () => {
             visibleTerms.map((item, index) => (
               <div
                 key={index}
-                className="bg-white dark:bg-[#1e293b] rounded-xl p-6 shadow-lg border border-gray-200 dark:border-[#334155] hover:border-blue-500 dark:hover:border-[#38bdf8] transition"
+                className="bg-white dark:bg-[#1e293b] rounded-xl p-6 shadow-lg border border-gray-200 dark:border-[#334155] hover:border-blue-500 dark:hover:border-[#38bdf8] transition h-full flex flex-col"
               >
                 <h2 className="text-xl font-semibold text-blue-600 dark:text-[#38bdf8]">{item.term}</h2>
-                <p className="text-gray-700 dark:text-gray-300 mt-2">{item.definition}</p>
+                <p className="text-gray-700 dark:text-gray-300 mt-2 flex-grow">{item.definition}</p>
                 {item.category && (
                   <span className="inline-block mt-3 text-sm text-amber-600 dark:text-amber-400 font-medium bg-amber-100 dark:bg-slate-700 px-2 py-1 rounded">
                     {item.category}


### PR DESCRIPTION
📝 Pull Request: Fix Glossary Card Alignment and Improve UI

🔧 Changes Made:
-Fixed inconsistent card heights in the glossary section.
-Implemented flex and h-full layout to ensure all cards align uniformly in the grid.
-Improved visual consistency and readability across different screen sizes.
-Minor UI tweaks for better responsiveness.

✅ Why This is Important:
-Previously, cards were misaligned due to varying content height.
-This affected visual balance and user experience.
-The fix ensures a clean, professional, and accessible layout.

📸 Before vs After:
❌ Before: Cards were uneven, breaking UI flow.
✅ After: All cards are evenly aligned, enhancing readability and design consistency.

🔗 Related Issue: #414