### PR TITLE
fixed issue: Add hover border/glow effect for Learning Path cards

### DIFF
--- a/src/Component/Paths/PathsLanding.jsx
+++ b/src/Component/Paths/PathsLanding.jsx
@@ -95,7 +95,9 @@ const PathsLanding = () => {
             return (
               <motion.div
                 key={p.slug}
-                className="border border-gray-200 dark:border-gray-800 rounded-2xl p-6 bg-white dark:bg-gray-900 shadow-sm hover:shadow-lg transition cursor-pointer flex flex-col justify-between"
+                className="border border-gray-200 dark:border-gray-800 rounded-2xl p-6 bg-white dark:bg-gray-900 shadow-sm cursor-pointer flex flex-col justify-between
+             transition-all duration-300 ease-in-out 
+             hover:border-blue-500 hover:shadow-[0_0_15px_rgba(59,130,246,0.3)] dark:hover:shadow-[0_0_15px_rgba(59,130,246,0.4)]"
                 whileHover={{ y: -4 }}
                 onClick={() => navigate(`/paths/${p.slug}`)}
               >


### PR DESCRIPTION
## Description
Added a hover border and subtle glow effect to the Learning Path cards to improve interactivity and provide visual feedback on hover.

## Which issue does this PR close?
Closes #425

## Rationale for this change
The Learning Paths section previously lacked a hover state, making cards feel static.  
This update introduces a smooth border and glow transition (`transition-all duration-300 ease-in-out`), creating a more dynamic and engaging experience for users.

## Changes made
- Added hover and subtle glow shadow to cards.
- Applied smooth transition timing.
- Ensured compatibility with dark mode.

